### PR TITLE
ajusta margem dos botões nos cards de relatórios

### DIFF
--- a/src/app/relatorios/relatorios-listar/relatorios-listar.component.scss
+++ b/src/app/relatorios/relatorios-listar/relatorios-listar.component.scss
@@ -23,6 +23,10 @@
   padding-top: 20px;
 }
 
+.btn-acessar {
+  margin: 0;
+}
+
 @media (max-width: 768px) {
   .card-horizontal {
       margin-bottom: 5vh;


### PR DESCRIPTION
Como os cards da seção de Relatórios não possuem imagem, a margem dos botões fica desalinhada. Este PR a elimina para resolver o problema. 